### PR TITLE
P2SH Outputs

### DIFF
--- a/lib/src/address.dart
+++ b/lib/src/address.dart
@@ -5,6 +5,7 @@ import 'package:coinslib/bech32/bech32.dart';
 import 'payments/index.dart' show PaymentData;
 import 'payments/p2pkh.dart';
 import 'payments/p2wpkh.dart';
+import 'payments/p2sh.dart';
 
 class Address {
   static bool validateAddress(String address, [NetworkType? nw]) {
@@ -17,32 +18,50 @@ class Address {
   }
 
   static Uint8List addressToOutputScript(String address, [NetworkType? nw]) {
+
     NetworkType network = nw ?? bitcoin;
     var decodeBase58;
     var decodeBech32;
+
     try {
       decodeBase58 = bs58check.decode(address);
     } catch (err) {}
+
     if (decodeBase58 != null) {
-      if (decodeBase58[0] != network.pubKeyHash)
-        throw new ArgumentError('Invalid version or Network mismatch');
-      P2PKH p2pkh =
-          new P2PKH(data: new PaymentData(address: address), network: network);
-      return p2pkh.data.output!;
-    } else {
-      try {
-        decodeBech32 = segwit.decode(address);
-      } catch (err) {}
-      if (decodeBech32 != null) {
-        if (network.bech32 != decodeBech32.hrp)
-          throw new ArgumentError('Invalid prefix or Network mismatch');
-        if (decodeBech32.version != 0)
-          throw new ArgumentError('Invalid address version');
-        P2WPKH p2wpkh = new P2WPKH(
-            data: new PaymentData(address: address), network: network);
-        return p2wpkh.data.output!;
+
+      final prefix = decodeBase58[0];
+      final data = decodeBase58.sublist(1);
+
+      if (prefix == network.pubKeyHash) {
+        P2PKH p2pkh = P2PKH(
+            data: PaymentData(address: address), network: network
+        );
+        return p2pkh.data.output!;
       }
+
+      if (prefix == network.scriptHash) {
+        return createP2shOutputScript(data);
+      }
+
+      throw ArgumentError('Invalid version or Network mismatch');
+
     }
+
+    try {
+      decodeBech32 = segwit.decode(address);
+    } catch (err) {}
+
+    if (decodeBech32 != null) {
+      if (network.bech32 != decodeBech32.hrp)
+        throw new ArgumentError('Invalid prefix or Network mismatch');
+      if (decodeBech32.version != 0)
+        throw new ArgumentError('Invalid address version');
+      P2WPKH p2wpkh = new P2WPKH(
+          data: new PaymentData(address: address), network: network);
+      return p2wpkh.data.output!;
+    }
+
     throw new ArgumentError(address + ' has no matching Script');
+
   }
 }

--- a/lib/src/payments/p2sh.dart
+++ b/lib/src/payments/p2sh.dart
@@ -1,0 +1,10 @@
+import 'dart:typed_data';
+import '../utils/script.dart' as bscript;
+import '../utils/constants/op.dart';
+
+/// Takes the hash160 ([scriptHash]) of a P2SH redeemScript and returns the
+/// output script (scriptPubKey)
+Uint8List createP2shOutputScript(Uint8List scriptHash) => bscript.compile([
+  OPS['OP_HASH160'], scriptHash, OPS['OP_EQUAL']
+]);
+

--- a/lib/src/payments/p2sh.dart
+++ b/lib/src/payments/p2sh.dart
@@ -4,7 +4,12 @@ import '../utils/constants/op.dart';
 
 /// Takes the hash160 ([scriptHash]) of a P2SH redeemScript and returns the
 /// output script (scriptPubKey)
-Uint8List createP2shOutputScript(Uint8List scriptHash) => bscript.compile([
-  OPS['OP_HASH160'], scriptHash, OPS['OP_EQUAL']
-]);
+Uint8List createP2shOutputScript(Uint8List scriptHash) {
+
+  if (scriptHash.length != 20)
+    throw new ArgumentError('Invalid script hash length');
+
+  return bscript.compile([OPS['OP_HASH160'], scriptHash, OPS['OP_EQUAL']]);
+
+}
 

--- a/test/address_test.dart
+++ b/test/address_test.dart
@@ -60,6 +60,34 @@ main() {
         expect(Address.validateAddress('3333333casca'), false);
       });
 
+      test('wrong size address', () {
+
+        expect(
+          Address.validateAddress('12D2adLM3UKy4Z4giRbReR6gjWx1w6Dz'),
+          false,
+          reason: "P2PKH too short"
+        );
+
+        expect(
+          Address.validateAddress('1QXEx2ZQ9mEdvMSaVKHznFv6iZq2LQbDz8'),
+          false,
+          reason: "P2PKH too long"
+        );
+
+        expect(
+          Address.validateAddress('TTazDDREDxxh1mPyGySut6H98h4UKPG6'),
+          false,
+          reason: "P2SH too short"
+        );
+
+        expect(
+          Address.validateAddress('9tT9KH26AxgN8j9uTpKdwUkK6LFcSKp4FpF'),
+          false,
+          reason: "P2SH too long"
+        );
+
+      });
+
     });
 
     group('addressToOutputScript', () {

--- a/test/address_test.dart
+++ b/test/address_test.dart
@@ -106,7 +106,7 @@ main() {
         expectScript(
           "3R2cuenjG5nFubqX9Wzuukdin2YfBbQ6Kw",
           "ffffffffffffffffffffffffffffffffffffffff"
-          );
+        );
 
       });
 

--- a/test/address_test.dart
+++ b/test/address_test.dart
@@ -1,10 +1,15 @@
+import 'dart:typed_data';
+
+import 'package:hex/hex.dart';
 import 'package:test/test.dart';
 import '../lib/src/address.dart' show Address;
 import '../lib/src/models/networks.dart' as NETWORKS;
 
 main() {
   group('Address', () {
+
     group('validateAddress', () {
+
       test('base58 addresses and valid network', () {
         expect(
             Address.validateAddress(
@@ -12,7 +17,11 @@ main() {
             true);
         expect(Address.validateAddress('1K6kARGhcX9nJpJeirgcYdGAgUsXD59nHZ'),
             true);
+        // P2SH
+        expect(Address.validateAddress('3L1YkZjdeNSqaZcNKZFXQfyokx3zVYm7r6'),
+            true);
       });
+
       test('base58 addresses and invalid network', () {
         expect(
             Address.validateAddress(
@@ -23,6 +32,7 @@ main() {
                 '1K6kARGhcX9nJpJeirgcYdGAgUsXD59nHZ', NETWORKS.testnet),
             false);
       });
+
       test('bech32 addresses and valid network', () {
         expect(
             Address.validateAddress(
@@ -34,6 +44,7 @@ main() {
             true);
         // expect(Address.validateAddress('tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy'), true); TODO
       });
+
       test('bech32 addresses and invalid network', () {
         expect(
             Address.validateAddress(
@@ -44,9 +55,34 @@ main() {
                 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', NETWORKS.testnet),
             false);
       });
+
       test('invalid addresses', () {
         expect(Address.validateAddress('3333333casca'), false);
       });
+
     });
+
+    group('addressToOutputScript', () {
+
+      test('returns p2sh scripts', () {
+
+        expectScript(address, expectedHash) {
+          final actual = Address.addressToOutputScript(address);
+          expect(HEX.encode(actual), "a914" + expectedHash + "87");
+        }
+
+        expectScript(
+          "31h1vYVSYuKP6AhS86fbRdMw9XHieotbST",
+          "0000000000000000000000000000000000000000"
+        );
+        expectScript(
+          "3R2cuenjG5nFubqX9Wzuukdin2YfBbQ6Kw",
+          "ffffffffffffffffffffffffffffffffffffffff"
+          );
+
+      });
+
+    });
+
   });
 }

--- a/test/integration/transactions_test.dart
+++ b/test/integration/transactions_test.dart
@@ -103,5 +103,28 @@ main() {
       expect(txb.build().toHex(),
           '010000000001015beda251af570014b7748c0adc5975b808e7b72a491353e1422d04f5266667530000000000ffffffff0240420f0000000000160014c5e1b9dad4c1dd0920ec3671b84d649877636f2fb8408900000000001600149d5e94ada1d095f60b701560f412d08a007d11590247304402203c4670ff81d352924af311552e0379861268bebb2222eeb0e66b3cdd1d4345b60220585b57982d958208cdd52f4ead4ecb86cfa9ff7740c2f6933e77135f1cc4c58f012102f9f43a191c6031a5ffae27c5f9911218e78857923284ac1154abc2cc008544b200000000');
     });
+
+    test('can create a P2SH output', () {
+
+      // Reusing key from above
+      final alice = ECPair.fromWIF(
+        'L1uyy5qTuGrVXrmrsvHWHgVzW9kKdrp27wBC7Vs6nZDTF2BRUVwy'
+      );
+
+      final txb = TransactionBuilder();
+      txb.setVersion(1);
+      txb.addInput(
+        '61d520ccb74288c96bc1a2b20ea1c0d5a704776dd0164a396efec3ea7040349d', 0
+      );
+      txb.addOutput('31nM1WuowNDzocNxPPW9NQWJEtwWpjfcLj', 1000);
+      txb.sign(vin: 0, keyPair: alice);
+
+      expect(
+        txb.build().toHex(),
+        '01000000019d344070eac3fe6e394a16d06d7704a7d5c0a10eb2a2c16bc98842b7cc20d561000000006a473044022012b7cd85d2d6ae54d2f2130533ac6db27fd9a0db52ad1625f8f5c246dc3994780220637d1c28328f56ec9747499e35f70c548a712743d9b0f467b4fde412c8511a9b0121029f50f51d63b345039a290c94bffd3180c99ed659ff6ea6b1242bca47eb93b59fffffffff01e80300000000000017a9140102030405060708090a0b0c0d0e0f10111213148700000000'
+      );
+
+    });
+
   });
 }


### PR DESCRIPTION
Here are the changes that accept P2SH addresses as outputs including tests. A P2SH address can now be provided to the `addOutput` method of `TransactionBuilder`.  `Address.validateAddress` will also validate these addresses.

Closes #16 