### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.1.7
 homepage: https://github.com/Vesta-wallet/coinslib
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   bip39: ^1.0.6


### PR DESCRIPTION
input_signature.dart:12:67 - This API is available since SDK 2.14.0, but constraints '>=2.12.0 <3.0.0' don't guarantee it.