### PR TITLE
Upgrade SDK constraint 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.1.8
 homepage: https://github.com/Vesta-wallet/coinslib
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.14.0 <4.0.0'
 
 dependencies:
   bip39: ^1.0.6


### PR DESCRIPTION
Package validation found the following hint:
* The declared SDK constraint is '>=2.14.0 <3.0.0', this is interpreted as '>=2.14.0 <4.0.0'.
  
  Consider updating the SDK constraint to:
  
  environment: sdk: '>=2.14.0 <4.0.0'